### PR TITLE
Add logo image to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<h1 align="center">ArtiGate</h1>
+<h1 align="center">
+  <img src="/docs/logo.svg" width="25%" alt="ArtiGate">
+</h1>
 
 <p align="center">
   <img src="https://img.shields.io/badge/React-18.3-61DAFB?logo=react&logoColor=white" alt="React 18"/>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,30 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="120" height="30" viewBox="0 0 120 30">
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="40" viewBox="0 0 150 40">
   <defs>
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Inter:wght@600&amp;display=swap');
       
       .text {
         font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        font-size: 20px;
+        font-size: 24px;
         font-weight: 600;
-        letter-spacing: -0.5px; /* equivalente ao tracking-tight do Tailwind */
+        letter-spacing: -0.5px;
+        text-anchor: middle; /* Aninha o texto pelo centro */
       }
       .arti {
-        fill: #4361EE; /* text-primary-500 */
+        fill: #4361EE;
       }
       .gate {
-        fill: #1B1D2C; /* text-ink-800 */
+        fill: #1B1D2C;
       }
       
-      /* Mágica do Modo Escuro do GitHub */
       @media (prefers-color-scheme: dark) {
         .gate {
-          fill: #F5F5F7; /* text-ink-50 para contraste no dark mode */
+          fill: #F5F5F7;
         }
       }
     </style>
   </defs>
-  <text x="2" y="22" class="text">
+  <!-- dominant-baseline e x=50% garantem o meio exato horizontal e vertical -->
+  <text x="50%" y="50%" dominant-baseline="central" class="text">
     <tspan class="arti">Arti</tspan><tspan class="gate">Gate</tspan>
   </text>
 </svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="30" viewBox="0 0 120 30">
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@600&amp;display=swap');
+      
+      .text {
+        font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: -0.5px; /* equivalente ao tracking-tight do Tailwind */
+      }
+      .arti {
+        fill: #4361EE; /* text-primary-500 */
+      }
+      .gate {
+        fill: #1B1D2C; /* text-ink-800 */
+      }
+      
+      /* Mágica do Modo Escuro do GitHub */
+      @media (prefers-color-scheme: dark) {
+        .gate {
+          fill: #F5F5F7; /* text-ink-50 para contraste no dark mode */
+        }
+      }
+    </style>
+  </defs>
+  <text x="2" y="22" class="text">
+    <tspan class="arti">Arti</tspan><tspan class="gate">Gate</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
* Branding update:
  * Replaced the `<h1>` project title with an embedded logo image (`/docs/logo.svg`) in the `README.md` file.