### PR TITLE
Update footer with new GitHub link and username

### DIFF
--- a/frontend/src/components/layout.component.tsx
+++ b/frontend/src/components/layout.component.tsx
@@ -39,12 +39,12 @@ const Layout: React.FC<LayoutProps> = ({
               <p>
                 &copy; {currentYear} ArtiGate &middot; Crafted by{' '}
                 <a
-                  href="https://github.com/azevedo1x"
+                  href="https://github.com/azevedo1z"
                   target="_blank"
                   rel="noopener noreferrer"
                   className={linkClassName}
                 >
-                  <span>azevedo1x</span>
+                  <span>azevedo1z</span>
                   <ExternalLink className="h-3 w-3" />
                 </a>
               </p>


### PR DESCRIPTION
This pull request makes a minor update to the footer in the `Layout` component, correcting the GitHub profile link and display name from `azevedo1x` to `azevedo1z`.